### PR TITLE
Fix rain volume can be float error

### DIFF
--- a/code/Models/OneCallModel.cs
+++ b/code/Models/OneCallModel.cs
@@ -9,7 +9,7 @@ public class Rain
     /// Rain volume for last hour, mm.
     /// </summary>
     [JsonProperty("1h")]
-    public int? PastHourVolume { get; set; }
+    public double? PastHourVolume { get; set; }
 }
 
 /// <summary>
@@ -21,7 +21,7 @@ public class Snow
     /// Snow volume for last hour, mm.
     /// </summary>
     [JsonProperty("1h")]
-    public int? PastHourVolume { get; set; }
+    public double? PastHourVolume { get; set; }
 }
 
 /// <summary>
@@ -563,13 +563,13 @@ public class Daily
     /// Precipitation volume in mm, can be null if not available.
     /// </summary>
     [JsonProperty("rain")]
-    public int? Rain { get; set; }
+    public double? Rain { get; set; }
 
     /// <summary>
     /// Snow volume in mm, can be null if not available.
     /// </summary>
     [JsonProperty("snow")]
-    public int? Snow { get; set; }
+    public double? Snow { get; set; }
 
     /// <summary>
     /// Information and a description of the weather.

--- a/code/Models/WeatherModel.cs
+++ b/code/Models/WeatherModel.cs
@@ -140,13 +140,13 @@ public class Rain
     /// Rain volume for the past hour in mm.
     /// </summary>
     [JsonProperty("1h")]
-    public int? PastHourVolume { get; set; }
+    public double? PastHourVolume { get; set; }
 
     /// <summary>
     /// Rain volume for the last 3 hours in mm.
     /// </summary>
     [JsonProperty("3h")]
-    public int? Past3HoursVolume { get; set; }
+    public double? Past3HoursVolume { get; set; }
 }
 
 /// <summary>
@@ -158,13 +158,13 @@ public class Snow
     /// Snow volume for the past hour in mm.
     /// </summary>
     [JsonProperty("1h")]
-    public int? PastHourVolume { get; set; }
+    public double? PastHourVolume { get; set; }
 
     /// <summary>
     /// Snow volume for the last 3 hours in mm.
     /// </summary>
     [JsonProperty("3h")]
-    public int? Past3HoursVolume { get; set; }
+    public double? Past3HoursVolume { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
This branch should fix the issue #2 , as all of the rain and snow related properties are now set to `double?` instead of `int?`.